### PR TITLE
Configure S3 Backend for Terraform State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Custom directory to store local files
+plans/

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    key    = "global/s3/terraform.tfstate"
+    region = "ap-south-1"
+
+    dynamodb_table = "tf-state-s3-dynamo-locks"
+    encrypt        = true
+  }
+}
+
+
+module "tf-state-backend-s3" {
+    source = "./tfinternal"
+}

--- a/tfinternal/main.tf
+++ b/tfinternal/main.tf
@@ -45,4 +45,8 @@ resource "aws_dynamodb_table" "tf_state_s3_locks" {
       name = "LockID"
       type = "S"
     }
+
+    point_in_time_recovery {
+      enabled = true
+    }
 }

--- a/tfinternal/main.tf
+++ b/tfinternal/main.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  region = "ap-south-1"
+}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket = "tf-state-712c84d7-480d-4beb-9e16-35f598cc7071"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tf_state_s3_versioning" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state_s3_bucket_sse" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state_s3_public_access" {
+  bucket                  = aws_s3_bucket.tf_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "tf_state_s3_locks" {
+    name = "tf-state-s3-dynamo-locks"
+    billing_mode = "PAY_PER_REQUEST"
+    hash_key = "LockID"
+
+    attribute {
+      name = "LockID"
+      type = "S"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new Terraform configuration for managing AWS resources related to state management.
	- Implemented S3 bucket and DynamoDB table for secure state storage and locking.
  
- **Chores**
	- Updated `.gitignore` to exclude the `plans/` directory from version control for cleaner repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->